### PR TITLE
Add try/catch for if an object is not iteratable

### DIFF
--- a/pysize.py
+++ b/pysize.py
@@ -23,8 +23,10 @@ def get_size(obj, seen=None):
         size += sum((get_size(v, seen) for v in obj.values()))
         size += sum((get_size(k, seen) for k in obj.keys()))
     elif hasattr(obj, '__iter__') and not isinstance(obj, (str, bytes, bytearray)):
-        size += sum((get_size(i, seen) for i in obj))
-        
+        try:
+            size += sum((get_size(i, seen) for i in obj))
+        except TypeError:
+            pass
     if hasattr(obj, '__slots__'): # can have __slots__ with __dict__
         size += sum(get_size(getattr(obj, s), seen) for s in obj.__slots__ if hasattr(obj, s))
         

--- a/pysize.py
+++ b/pysize.py
@@ -29,7 +29,7 @@ def get_size(obj, seen=None):
         try:
             size += sum((get_size(i, seen) for i in obj))
         except TypeError:
-            logger.warning("Unable to get size of %r. This may lead to incorrect sizes. Please report this error.", obj)
+            logging.exception("Unable to get size of %r. This may lead to incorrect sizes. Please report this error.", obj)
     if hasattr(obj, '__slots__'): # can have __slots__ with __dict__
         size += sum(get_size(getattr(obj, s), seen) for s in obj.__slots__ if hasattr(obj, s))
         

--- a/pysize.py
+++ b/pysize.py
@@ -1,5 +1,8 @@
 import sys
 import inspect
+import logging
+
+logger = logging.getLogger(__name__)
 
 def get_size(obj, seen=None):
     """Recursively finds size of objects in bytes"""
@@ -26,7 +29,7 @@ def get_size(obj, seen=None):
         try:
             size += sum((get_size(i, seen) for i in obj))
         except TypeError:
-            pass
+            logger.warning("Unable to get size of %r. This may lead to incorrect sizes. Please report this error.", obj)
     if hasattr(obj, '__slots__'): # can have __slots__ with __dict__
         size += sum(get_size(getattr(obj, s), seen) for s in obj.__slots__ if hasattr(obj, s))
         


### PR DESCRIPTION
As was noted in https://github.com/bosswissam/pysize/issues/8, it is possible for some objects to have `hasattr(obj, '__iter__')` be `True`, and still not be iterable.

The python language docs say: 
> Checking isinstance(obj, [Iterable](https://docs.python.org/3/library/collections.abc.html#collections.abc.Iterable)) detects classes that are registered as Iterable or that have an __iter__() method, but it does not detect classes that iterate with the __getitem__() method. The only reliable way to determine whether an object is [iterable](https://docs.python.org/3/glossary.html#term-iterable) is to call iter(obj).

See: https://docs.python.org/3/library/collections.abc.html#collections.abc.Iterable

This may cause a bit of a performance hit for this code, but I think it is the complete solution for this general problem.

I'm not sure if there is another way to add up the size of the object that should be attempted if the `TypeError` is caught, but I'm happy to add to the PR if you have thoughts.